### PR TITLE
Fix game view scaling on macOS retina screens

### DIFF
--- a/platform/osx/ZXGameView.m
+++ b/platform/osx/ZXGameView.m
@@ -527,6 +527,10 @@ failure:
   baseRect = [self bounds];
   viewSize = baseRect.size;
 
+  CGFloat screenScale = self.window.screen.backingScaleFactor ?: 1;
+  viewSize.width *= screenScale;
+  viewSize.height *= screenScale;
+  
   // How many 1:1 game windows fit comfortably into the view?
   // Try to fit while reducing the border if the view is very small
   reducedBorder = borderSize;

--- a/platform/osx/ZXGameView.m
+++ b/platform/osx/ZXGameView.m
@@ -209,9 +209,9 @@ failure:
   zxspectrum_destroy(zx);
 }
 
-- (void)reshape
+- (void)update
 {
-  [super reshape];
+  [super update];
   doSetupDrawing = YES;
 }
 


### PR DESCRIPTION
Couple of minor updates to handle retina screens on macOS and moving the game window between retina and non-retina displays on the same Mac.